### PR TITLE
Validate if properties with type 'file' are readable streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Once your server is set to use ratify, you can specify route-specific validation
 All schemas should follow the [JSON schema specification](http://json-schema.org/).
 
 ***Notes:***
-In addition to the JSON schema defined types, ratify allows you to specify "file" as a payload type. If this is specified, no validation against JSON schema is performed, but swagger documentation will still be provided.
+In addition to the JSON schema defined types, ratify allows you to specify "file" as a payload type. If this is specified, ratify validates if the file object is a readable stream.
 
 #### Type Conversion
 

--- a/lib/RouteSchemaManager.js
+++ b/lib/RouteSchemaManager.js
@@ -1,5 +1,6 @@
 var ZSchema = require('z-schema'),
 	_ = require('lodash'),
+	isStream = require('is-stream'),
 	validator = new ZSchema();
 
 var RouteSchemaManager = function(options) {
@@ -72,12 +73,17 @@ var RouteSchemaManager = function(options) {
 												modifyHeadersSchema(validationOption) :
 												validationOption;
 
-				// don't validate file type payloads and void responses
-				if (validationType === validationTypes.PAYLOAD && validationSchema.type === 'file' ||
-					(validationType === validationTypes.RESPONSE && (!validationSchema || validationSchema.type === 'void'))) {
+				// don't validate void responses
+				if (validationType === validationTypes.RESPONSE && (!validationSchema || validationSchema.type === 'void')) {
 					return;
 				}
 				var schemaKey = constructSchemaKey(validationType, route.method, route.path);
+
+				// don't validate file payloads here
+				if (validationType === validationTypes.PAYLOAD && validationSchema.type === 'file') {
+					schemas[schemaKey] = validationSchema;
+					return;
+				}
 
 				if (!validator.validateSchema(validationSchema)){
 					throw new Error('Failed to validate schema for route: ' + route.path +
@@ -172,6 +178,41 @@ var RouteSchemaManager = function(options) {
 					}
 				}
 			}
+		},
+
+		invalidFileInPayload = {
+			valid: false,
+			errors: [
+				{
+					code: 'INVALID_TYPE',
+					message: 'Invalid multipart payload format',
+				}
+			]
+		},
+
+		validateFileProperties = function (schema, request) {
+			var isFilePayload = false,
+				hasFilePayloadError = false;
+			if (schema.type === 'file' && !schema.properties) {
+				isFilePayload = true;
+				if (!isStream.readable(request.payload)) {
+					hasFilePayloadError = true;
+				}
+			}
+			if (schema.properties) {
+				Object.keys(schema.properties).forEach(function (prop) {
+					if (schema.properties[prop].type === 'file') {
+						isFilePayload = true;
+						if (prop in request.payload && !isStream.readable(request.payload[prop])) {
+							hasFilePayloadError = true;
+						}
+					}
+				});
+			}
+			return {
+				isFilePayload: isFilePayload,
+				result: hasFilePayloadError ? invalidFileInPayload : { valid: true }
+			};
 		};
 
 	this.initializeRoutes = function(serverUri, routes) {
@@ -235,6 +276,13 @@ var RouteSchemaManager = function(options) {
 					!(typeof request.payload === 'object' &&
 						Object.keys(request.payload).length === 0)){
 			return { valid: false, errors: ['unable to validate payload: missing content-type header and had content'] };
+		}
+
+		// for properties with type 'file', check if the payload contains a readable stream
+		var schema = schemas[validationTypes.PAYLOAD];
+		var fileValidation = validateFileProperties(schema, request);
+		if (fileValidation.isFilePayload) {
+			return fileValidation.result;
 		}
 
 		// convert payload types before validating only if payload is type application/x-www-form-urlencoded or multipart/form-data

--- a/package.json
+++ b/package.json
@@ -4,14 +4,15 @@
 	"contributors": [
 		"Mac Angell <mac.ang311@gmail.com>"
 	],
-	"version": "2.0.0",
+	"version": "2.2.0",
 	"dependencies": {
 		"hoek": "^3.0.4",
 		"z-schema": "^3.0.1",
 		"z-schema-errors": "^0.2.0",
 		"capitalize": "^1.0.0",
 		"lodash": "^3.9.1",
-		"boom": "^3.0.0"
+		"boom": "^3.0.0",
+		"is-stream": "1.0.1"
 	},
 	"devDependencies": {
 		"mocha": "1.x.x",

--- a/test/RouteSchemaManager.tests.js
+++ b/test/RouteSchemaManager.tests.js
@@ -161,6 +161,30 @@ var assert = require('assert'),
 			}
 		}
 	},
+	mockRoute7 = {
+		method: 'POST',
+		path: '/good/fnord',
+		server: {
+			info: {
+				uri: 'http://fnord.com'
+			}
+		},
+		settings: {
+			plugins: {
+				ratify: {
+					payload: {
+						type: 'file',
+						properties: {
+							users: {
+								type: 'file'
+							},
+							numberArray: numberArraySchema
+						}
+					}
+				}
+			}
+		}
+	},
 	mockRoutes = [mockRoute1, mockRoute2, mockRoute4];
 
 describe('RouteSchemaManager Unit Tests', function() {
@@ -451,10 +475,10 @@ describe('RouteSchemaManager Unit Tests', function() {
 
 		it('should validate payload for route successfully for a file upload', function() {
 			var fs = require('fs');
-			var data = fs.readFileSync('./test/jshint/config.json');
+			var data = fs.createReadStream('./test/jshint/config.json');
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				mockRequest = {
-					_route: mockRoute1,
+					_route: mockRoute5,
 					payload: data,
 					raw: {
 						req: {
@@ -468,14 +492,15 @@ describe('RouteSchemaManager Unit Tests', function() {
 			var report = routeSchemaManager.validatePayload(mockRequest);
 			assert(report.valid, 'file payload should be valid');
 		});
-		
-		it('should validate payload for route successfully for a file upload with array data', function() {
+
+		it('should validate payload for route successfully for a file upload with extra data', function() {
 			var fs = require('fs');
-			var data = fs.readFileSync('./test/jshint/config.json');
+			var data = fs.createReadStream('./test/jshint/config.json');
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				mockRequest = {
-					_route: mockRoute1,
+					_route: mockRoute7,
 					payload: {
+						users: data,
 						numberArray: ['5', '6']
 					},
 					raw: {
@@ -486,9 +511,9 @@ describe('RouteSchemaManager Unit Tests', function() {
 						}
 					}
 				};
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, [mockRoute1]);
+			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, [mockRoute7]);
 			var report = routeSchemaManager.validatePayload(mockRequest);
-			assert(report.valid, 'file payload should be valid');
+			assert(report.valid, 'file payload with extra data should be valid');
 		});
 		
 		it('should validate payload for route with no payload schema successfully', function() {


### PR DESCRIPTION
If a payload (or any of its properties) has `type == 'file'`, check if it's a readable stream and, if not, return an error.