### PR TITLE
Supports HAPI 17 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ node_modules
 lib-test
 test/coverage*
 .DS*
+
+#IDE
+.idea

--- a/README.md
+++ b/README.md
@@ -172,4 +172,5 @@ Ratify automatically generates routes that produce JSON in the format of the [Sw
 * 1.x.x - Hapi 10.x.x (Node v4)
 * 2.x.x - Hapi 11.x.x
 * 3.x.x - Hapi 16.x.x
+* 4.x.x - Hapi 17.x.x
 

--- a/lib/RequestValidator.js
+++ b/lib/RequestValidator.js
@@ -30,7 +30,7 @@ var RequestValidator = function(plugin, options) {
 			}
 			catch (error){
 				log('error', 'Unable to compile and validate schemas', error);
-				return error;
+				throw error;
 			}
 
 			return h.continue;
@@ -45,7 +45,7 @@ var RequestValidator = function(plugin, options) {
 				report = routeSchemaManager['validate' + capitalizedParts](request);
 
 				if (!report.valid){
-					return Boom.badRequest(configuredErrorReporters[parts[i]].extractMessage({ report: report, context: { request: request } }));
+					throw Boom.badRequest(configuredErrorReporters[parts[i]].extractMessage({ report: report, context: { request: request } }));
 				}
 			}
 
@@ -83,7 +83,7 @@ var RequestValidator = function(plugin, options) {
 						request.log(['validation', 'error'], errorMessages);
 						return h.continue;
 					}
-					return Boom.internal(errorMessages);
+					throw Boom.internal(errorMessages);
 				}
 			}
 			return h.continue;

--- a/lib/RequestValidator.js
+++ b/lib/RequestValidator.js
@@ -21,25 +21,22 @@ var RequestValidator = function(plugin, options) {
 	var routeSchemaManager = new RouteSchemaManager({ pluginName: options.pluginName, log: options.log }),
 		log = options.log || function(){},
 
-		onRequest = function(request, reply) {
+		onRequest = function(request, h) {
 			// hand routes for this server to schema manager so it can compile the schemas for each route
 			// this method will not attempt to compile them more than once, so this is safe to call on every request
 			try {
-				var connectionsWithTable = request.server.table();
-
-				connectionsWithTable.forEach(function(cwt){
-					routeSchemaManager.initializeRoutes(cwt.info.uri, cwt.table);
-				});
+				var table = request.server.table();
+        routeSchemaManager.initializeRoutes(table);
 			}
 			catch (error){
 				log('error', 'Unable to compile and validate schemas', error);
-				return reply(error);
+				return error;
 			}
 
-			reply.continue();
+			return h.continue;
 		},
 
-		onPreHandler = function(request, reply) {
+		onPreHandler = function(request, h) {
 			var report,
 				parts = ['path', 'query', 'headers', 'payload'];
 
@@ -48,14 +45,14 @@ var RequestValidator = function(plugin, options) {
 				report = routeSchemaManager['validate' + capitalizedParts](request);
 
 				if (!report.valid){
-					return reply(Boom.badRequest(configuredErrorReporters[parts[i]].extractMessage({ report: report, context: { request: request } })));
+					return Boom.badRequest(configuredErrorReporters[parts[i]].extractMessage({ report: report, context: { request: request } }));
 				}
 			}
 
-			reply.continue();
+			return h.continue;
 		},
 
-		onPostHandler = function(request, reply) {
+		onPostHandler = function(request, h) {
 			var report, errorMessages;
 
 			// if route config contains a schema for the respose, and sample rate is greater than 0, validate it
@@ -70,12 +67,12 @@ var RequestValidator = function(plugin, options) {
 				if (request.route.settings.plugins[options.pluginName].response.sample) {
 					var currentSample = Math.ceil((Math.random() * 100));
 					if (currentSample > request.route.settings.plugins[options.pluginName].response.sample) {
-						return reply.continue();
+						return h.continue;
 					}
 				}
 
 				if (request.response.isBoom) {
-					return reply.continue();
+					return h.continue;
 				}
 
 				report = routeSchemaManager.validateResponse(request);
@@ -84,12 +81,12 @@ var RequestValidator = function(plugin, options) {
 
 					if (request.route.settings.plugins[options.pluginName].response.failAction === 'log') {
 						request.log(['validation', 'error'], errorMessages);
-						return reply.continue();
+						return h.continue;
 					}
-					return reply(Boom.internal(errorMessages));
+					return Boom.internal(errorMessages);
 				}
 			}
-			reply.continue();
+			return h.continue;
 		};
 
 	// hook for compiling all schemas for all routes (one time)

--- a/lib/RouteSchemaManager.js
+++ b/lib/RouteSchemaManager.js
@@ -6,7 +6,7 @@ var ZSchema = require('z-schema'),
 var RouteSchemaManager = function(options) {
 	options = options || {};
 
-	var schemasByServerUri = {},
+	var schemasByKey = {},
 		validationTypes = {
 			PATH: 'path',
 			QUERY: 'query',
@@ -102,7 +102,7 @@ var RouteSchemaManager = function(options) {
 			forEachValidationOption(route, function(validationOption, validationType) {
 				schemas = schemas || {};
 				var key = constructSchemaKey(validationType, route.method, route.path);
-				schemas[validationType] = schemasByServerUri[key];
+				schemas[validationType] = schemasByKey[key];
 			});
 			return schemas;
 		},
@@ -214,8 +214,8 @@ var RouteSchemaManager = function(options) {
 
 	this.initializeRoutes = function(routes) {
 		routes.forEach(function(route) {
-			schemasByServerUri = _.extend(
-				schemasByServerUri,
+			schemasByKey = _.extend(
+				schemasByKey,
 				generateSchemasForRoute(route));
 		});
 	};

--- a/lib/RouteSchemaManager.js
+++ b/lib/RouteSchemaManager.js
@@ -98,15 +98,12 @@ var RouteSchemaManager = function(options) {
 		},
 
 		getSchemasForRoute = function(route) {
-			var schemas = null,
-				serverUri = route.server.info.uri;
-			if (schemasByServerUri[serverUri]) {
-				forEachValidationOption(route, function(validationOption, validationType) {
-					schemas = schemas || {};
-					var key = constructSchemaKey(validationType, route.method, route.path);
-					schemas[validationType] = schemasByServerUri[serverUri][key];
-				});
-			}
+			var schemas = null;
+			forEachValidationOption(route, function(validationOption, validationType) {
+				schemas = schemas || {};
+				var key = constructSchemaKey(validationType, route.method, route.path);
+				schemas[validationType] = schemasByServerUri[key];
+			});
 			return schemas;
 		},
 
@@ -215,20 +212,16 @@ var RouteSchemaManager = function(options) {
 			};
 		};
 
-	this.initializeRoutes = function(serverUri, routes) {
-		if (!schemasByServerUri[serverUri]) {
-			schemasByServerUri[serverUri] = {};
-
-			routes.forEach(function(route) {
-				schemasByServerUri[serverUri] = _.extend(
-					schemasByServerUri[serverUri],
-					generateSchemasForRoute(route));
-			});
-		}
+	this.initializeRoutes = function(routes) {
+		routes.forEach(function(route) {
+			schemasByServerUri = _.extend(
+				schemasByServerUri,
+				generateSchemasForRoute(route));
+		});
 	};
 
 	this.validatePath = function(request) {
-		var schemas = getSchemasForRoute(request._route);
+		var schemas = getSchemasForRoute(request.route);
 		if (!schemas || !schemas[validationTypes.PATH]) {
 			return { valid: true };
 		}
@@ -247,7 +240,7 @@ var RouteSchemaManager = function(options) {
 	};
 
 	this.validateQuery = function(request) {
-		var schemas = getSchemasForRoute(request._route);
+		var schemas = getSchemasForRoute(request.route);
 		if (!schemas || !schemas[validationTypes.QUERY]) {
 			return { valid: true };
 		}
@@ -265,7 +258,7 @@ var RouteSchemaManager = function(options) {
 	};
 
 	this.validatePayload = function(request) {
-		var schemas = getSchemasForRoute(request._route);
+		var schemas = getSchemasForRoute(request.route);
 		if (!schemas || !schemas[validationTypes.PAYLOAD]) {
 			return { valid: true };
 		}
@@ -300,7 +293,7 @@ var RouteSchemaManager = function(options) {
 	};
 
 	this.validateHeaders = function(request) {
-		var schemas = getSchemasForRoute(request._route);
+		var schemas = getSchemasForRoute(request.route);
 		if (!schemas || !schemas[validationTypes.HEADERS]) {
 			return { valid: true };
 		}
@@ -317,7 +310,7 @@ var RouteSchemaManager = function(options) {
 	};
 
 	this.validateResponse = function(request) {
-		var schemas = getSchemasForRoute(request._route);
+		var schemas = getSchemasForRoute(request.route);
 		if (!schemas || !schemas[validationTypes.RESPONSE]) {
 			return { valid: true };
 		}

--- a/lib/ratify.js
+++ b/lib/ratify.js
@@ -39,7 +39,7 @@ function register(plugin, options) {
 					return swaggerManager.getApiDeclarationModel(routes, request.params.path);
 				}
 				else {
-					return Boom.notFound();
+					throw Boom.notFound();
 				}
 			}
 		}

--- a/lib/ratify.js
+++ b/lib/ratify.js
@@ -15,9 +15,9 @@ var RequestValidator = require('./RequestValidator.js'),
 	};
 
 
-module.exports.register = function (plugin, options, next) {
+function register(plugin, options) {
 
-	var settings = Hoek.applyToDefaults(defaults, options || {}),
+	const settings = Hoek.applyToDefaults(defaults, options || {}),
 		swaggerManager = new SwaggerManager(settings);
 
 	plugin.route({
@@ -25,24 +25,21 @@ module.exports.register = function (plugin, options, next) {
 		path: settings.startingPath + '/{path*}',
 		config: {
 			auth: settings.auth,
-			handler: function(request, reply) {
-				var connectionId = request.connection.info.id;
-				var routes = request.server.table().filter(function(c){
-					return c.info.id === connectionId;
-				})[0].table;
+			handler: function(request) {
+				let routes = request.server.table();
 
 				routes = routes.filter(function (item) {
-					return (request._route.path !== item.path && item.method !== 'options');
+					return (request.route.path !== item.path && item.method !== 'options');
 				});
 
 				if (!request.params.path) {
-					reply(swaggerManager.getResourceListingModel(routes));
+					return swaggerManager.getResourceListingModel(routes);
 				}
 				else if (request.params.path && swaggerManager.isValidApi(routes, request.params.path)) {
-					reply(swaggerManager.getApiDeclarationModel(routes, request.params.path));
+					return swaggerManager.getApiDeclarationModel(routes, request.params.path);
 				}
 				else {
-					reply(Boom.notFound());
+					return Boom.notFound();
 				}
 			}
 		}
@@ -50,10 +47,9 @@ module.exports.register = function (plugin, options, next) {
 
 
 	RequestValidator(plugin, settings);
+}
 
-	next();
-};
-
-module.exports.register.attributes = {
-	pkg: require('../package.json')
+module.exports = {
+	name: 'ratify',
+	register
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "contributors": [
     "Mac Angell <mac.ang311@gmail.com>"
   ],
-  "version": "3.0.0-auth0",
+  "version": "4.0.0-auth0",
   "dependencies": {
     "hoek": "^3.0.4",
     "z-schema": "^3.0.1",
@@ -15,15 +15,18 @@
     "is-stream": "1.0.1"
   },
   "devDependencies": {
-    "mocha": "1.x.x",
+    "mocha": "^3.4.2",
     "jshint": "2.x.x",
     "travis-cov": "0.x.x",
     "blanket": "1.x.x",
     "rewire": "2.x.x",
     "coveralls": "2.x.x",
     "mocha-lcov-reporter": "0.x.x",
-    "hapi": "^11.1.1",
+    "hapi": "^17.0.0",
     "catbox-memory": "^2.0.1"
+  },
+  "peerDependencies": {
+    "hapi": ">=17.x.x"
   },
   "keywords": [
     "hapi",
@@ -36,7 +39,7 @@
     "docs"
   ],
   "engines": {
-    "node": ">=4.2.0"
+    "node": ">=8.9.0"
   },
   "main": "./lib/ratify.js",
   "repository": {

--- a/test/RouteSchemaManager.tests.js
+++ b/test/RouteSchemaManager.tests.js
@@ -191,20 +191,20 @@ var assert = require('assert'),
 describe('RouteSchemaManager Unit Tests', function() {
 
 /*
-	d8b          d8b 888    d8b          888 d8b                   8888888b.                   888                     
-	Y8P          Y8P 888    Y8P          888 Y8P                   888   Y88b                  888                     
-	                 888                 888                       888    888                  888                     
-	888 88888b.  888 888888 888  8888b.  888 888 88888888  .d88b.  888   d88P .d88b.  888  888 888888 .d88b.  .d8888b  
-	888 888 "88b 888 888    888     "88b 888 888    d88P  d8P  Y8b 8888888P" d88""88b 888  888 888   d8P  Y8b 88K      
-	888 888  888 888 888    888 .d888888 888 888   d88P   88888888 888 T88b  888  888 888  888 888   88888888 "Y8888b. 
-	888 888  888 888 Y88b.  888 888  888 888 888  d88P    Y8b.     888  T88b Y88..88P Y88b 888 Y88b. Y8b.          X88 
+	d8b          d8b 888    d8b          888 d8b                   8888888b.                   888
+	Y8P          Y8P 888    Y8P          888 Y8P                   888   Y88b                  888
+	                 888                 888                       888    888                  888
+	888 88888b.  888 888888 888  8888b.  888 888 88888888  .d88b.  888   d88P .d88b.  888  888 888888 .d88b.  .d8888b
+	888 888 "88b 888 888    888     "88b 888 888    d88P  d8P  Y8b 8888888P" d88""88b 888  888 888   d8P  Y8b 88K
+	888 888  888 888 888    888 .d888888 888 888   d88P   88888888 888 T88b  888  888 888  888 888   88888888 "Y8888b.
+	888 888  888 888 Y88b.  888 888  888 888 888  d88P    Y8b.     888  T88b Y88..88P Y88b 888 Y88b. Y8b.          X88
 	888 888  888 888  "Y888 888 "Y888888 888 888 88888888  "Y8888  888   T88b "Y88P"   "Y88888  "Y888 "Y8888   88888P'
 */
 	describe('initializeRoutes', function() {
 		it('should not compile the same routes more than once', function() {
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig);
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, mockRoutes);
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, mockRoutes);
+			routeSchemaManager.initializeRoutes(mockRoutes);
+			routeSchemaManager.initializeRoutes(mockRoutes);
 			// if it gets here no errors were thrown
 		});
 
@@ -212,7 +212,7 @@ describe('RouteSchemaManager Unit Tests', function() {
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig);
 			var error;
 			try {
-				routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, [mockRoute3]);
+				routeSchemaManager.initializeRoutes([mockRoute3]);
 			}
 			catch (er){
 				error = er;
@@ -223,13 +223,13 @@ describe('RouteSchemaManager Unit Tests', function() {
 	});
 
 /*
-	                  888 d8b      888          888            8888888b.          888    888      
-	                  888 Y8P      888          888            888   Y88b         888    888      
-	                  888          888          888            888    888         888    888      
-	888  888  8888b.  888 888  .d88888  8888b.  888888 .d88b.  888   d88P 8888b.  888888 88888b.  
-	888  888     "88b 888 888 d88" 888     "88b 888   d8P  Y8b 8888888P"     "88b 888    888 "88b 
-	Y88  88P .d888888 888 888 888  888 .d888888 888   88888888 888       .d888888 888    888  888 
-	 Y8bd8P  888  888 888 888 Y88b 888 888  888 Y88b. Y8b.     888       888  888 Y88b.  888  888 
+	                  888 d8b      888          888            8888888b.          888    888
+	                  888 Y8P      888          888            888   Y88b         888    888
+	                  888          888          888            888    888         888    888
+	888  888  8888b.  888 888  .d88888  8888b.  888888 .d88b.  888   d88P 8888b.  888888 88888b.
+	888  888     "88b 888 888 d88" 888     "88b 888   d8P  Y8b 8888888P"     "88b 888    888 "88b
+	Y88  88P .d888888 888 888 888  888 .d888888 888   88888888 888       .d888888 888    888  888
+	 Y8bd8P  888  888 888 888 Y88b 888 888  888 Y88b. Y8b.     888       888  888 Y88b.  888  888
 	  Y88P   "Y888888 888 888  "Y88888 "Y888888  "Y888 "Y8888  888       "Y888888  "Y888 888  888
 */
 	describe('validatePath', function() {
@@ -237,13 +237,13 @@ describe('RouteSchemaManager Unit Tests', function() {
 
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				mockRequest = {
-					_route: mockRoute1,
+					route: mockRoute1,
 					params: {
 						string: 'fnord',
 						number: '12345'
 					}
 				};
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, mockRoutes);
+			routeSchemaManager.initializeRoutes(mockRoutes);
 			var report = routeSchemaManager.validatePath(mockRequest);
 			assert(report.valid, 'path obj should be valid');
 		});
@@ -251,13 +251,13 @@ describe('RouteSchemaManager Unit Tests', function() {
 		it('should validate path params for route with no path schema successfully', function() {
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				mockRequest = {
-					_route: mockRoute2,
+					route: mockRoute2,
 					params: {
 						string: 'fnord',
 						number: '12345'
 					}
 				};
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, mockRoutes);
+			routeSchemaManager.initializeRoutes(mockRoutes);
 			var report = routeSchemaManager.validatePath(mockRequest);
 			assert(report.valid, 'path obj should be valid');
 		});
@@ -265,13 +265,13 @@ describe('RouteSchemaManager Unit Tests', function() {
 		it('should fail validation of path params', function() {
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				mockRequest = {
-					_route: mockRoute1,
+					route: mockRoute1,
 					params: {
 						string: true,
 						number: []
 					}
 				};
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, mockRoutes);
+			routeSchemaManager.initializeRoutes(mockRoutes);
 			var report = routeSchemaManager.validatePath(mockRequest);
 			assert(!report.valid, 'path obj should not be valid');
 			assert(report.errors, 'errors obj should be valid');
@@ -279,23 +279,23 @@ describe('RouteSchemaManager Unit Tests', function() {
 	});
 
 /*
-	                  888 d8b      888          888             .d88888b.                                     
-	                  888 Y8P      888          888            d88P" "Y88b                                    
-	                  888          888          888            888     888                                    
-	888  888  8888b.  888 888  .d88888  8888b.  888888 .d88b.  888     888 888  888  .d88b.  888d888 888  888 
-	888  888     "88b 888 888 d88" 888     "88b 888   d8P  Y8b 888     888 888  888 d8P  Y8b 888P"   888  888 
-	Y88  88P .d888888 888 888 888  888 .d888888 888   88888888 888 Y8b 888 888  888 88888888 888     888  888 
-	 Y8bd8P  888  888 888 888 Y88b 888 888  888 Y88b. Y8b.     Y88b.Y8b88P Y88b 888 Y8b.     888     Y88b 888 
-	  Y88P   "Y888888 888 888  "Y88888 "Y888888  "Y888 "Y8888   "Y888888"   "Y88888  "Y8888  888      "Y88888 
-	                                                                  Y8b                                 888 
-	                                                                                                 Y8b d88P 
+	                  888 d8b      888          888             .d88888b.
+	                  888 Y8P      888          888            d88P" "Y88b
+	                  888          888          888            888     888
+	888  888  8888b.  888 888  .d88888  8888b.  888888 .d88b.  888     888 888  888  .d88b.  888d888 888  888
+	888  888     "88b 888 888 d88" 888     "88b 888   d8P  Y8b 888     888 888  888 d8P  Y8b 888P"   888  888
+	Y88  88P .d888888 888 888 888  888 .d888888 888   88888888 888 Y8b 888 888  888 88888888 888     888  888
+	 Y8bd8P  888  888 888 888 Y88b 888 888  888 Y88b. Y8b.     Y88b.Y8b88P Y88b 888 Y8b.     888     Y88b 888
+	  Y88P   "Y888888 888 888  "Y88888 "Y888888  "Y888 "Y8888   "Y888888"   "Y88888  "Y8888  888      "Y88888
+	                                                                  Y8b                                 888
+	                                                                                                 Y8b d88P
 	                                                                                                  "Y88P"
 */
 	describe('validateQuery', function() {
 		it('should validate query params for route successfully', function() {
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				mockRequest = {
-					_route: mockRoute1,
+					route: mockRoute1,
 					query: {
 						string: 'fnord',
 						array: [
@@ -304,7 +304,7 @@ describe('RouteSchemaManager Unit Tests', function() {
 						]
 					}
 				};
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, mockRoutes);
+			routeSchemaManager.initializeRoutes(mockRoutes);
 			var report = routeSchemaManager.validateQuery(mockRequest);
 			assert(report.valid, 'query obj should be valid');
 		});
@@ -313,10 +313,10 @@ describe('RouteSchemaManager Unit Tests', function() {
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				query = querystring.parse('string=fnord&array[0]=fnord1&array[1]=fnord2'),
 				mockRequest = {
-					_route: mockRoute2,
+					route: mockRoute2,
 					query: query
 				};
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, mockRoutes);
+			routeSchemaManager.initializeRoutes(mockRoutes);
 			var report = routeSchemaManager.validateQuery(mockRequest);
 			assert(report.valid, 'query obj should be valid');
 		});
@@ -325,10 +325,10 @@ describe('RouteSchemaManager Unit Tests', function() {
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				query = querystring.parse('string=fnord&array=fnord1'),
 				mockRequest = {
-					_route: mockRoute1,
+					route: mockRoute1,
 					query: query
 				};
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, mockRoutes);
+			routeSchemaManager.initializeRoutes(mockRoutes);
 			var report = routeSchemaManager.validateQuery(mockRequest);
 			assert(report.valid, 'query obj should be valid');
 		});
@@ -338,10 +338,10 @@ describe('RouteSchemaManager Unit Tests', function() {
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				query = querystring.parse('string=fnord&array[0]=fnord1&array[1]=fnord2'),
 				mockRequest = {
-					_route: mockRoute1,
+					route: mockRoute1,
 					query: query
 				};
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, mockRoutes);
+			routeSchemaManager.initializeRoutes(mockRoutes);
 			var report = routeSchemaManager.validateQuery(mockRequest);
 			assert(report.valid, 'query obj should be valid');
 		});
@@ -351,10 +351,10 @@ describe('RouteSchemaManager Unit Tests', function() {
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				query = querystring.parse('string=fnord&bool=true'),
 				mockRequest = {
-					_route: mockRoute1,
+					route: mockRoute1,
 					query: query
 				};
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, mockRoutes);
+			routeSchemaManager.initializeRoutes(mockRoutes);
 			var report = routeSchemaManager.validateQuery(mockRequest);
 			assert(report.valid, 'query obj should be valid');
 		});
@@ -363,10 +363,10 @@ describe('RouteSchemaManager Unit Tests', function() {
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				query = querystring.parse('string=fnord&bool=false'),
 				mockRequest = {
-					_route: mockRoute1,
+					route: mockRoute1,
 					query: query
 				};
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, mockRoutes);
+			routeSchemaManager.initializeRoutes(mockRoutes);
 			var report = routeSchemaManager.validateQuery(mockRequest);
 			assert(report.valid, 'query obj should be valid');
 		});
@@ -376,10 +376,10 @@ describe('RouteSchemaManager Unit Tests', function() {
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				query = querystring.parse('string=fnord&array[fnord]=1&bool=truefalse'),
 				mockRequest = {
-					_route: mockRoute1,
+					route: mockRoute1,
 					query: query
 				};
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, mockRoutes);
+			routeSchemaManager.initializeRoutes(mockRoutes);
 			var report = routeSchemaManager.validateQuery(mockRequest);
 			assert(!report.valid, 'query obj should not be valid');
 		});
@@ -388,12 +388,12 @@ describe('RouteSchemaManager Unit Tests', function() {
 
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				mockRequest = {
-					_route: mockRoute1,
+					route: mockRoute1,
 					query: {
 						string: true
 					}
 				};
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, mockRoutes);
+			routeSchemaManager.initializeRoutes(mockRoutes);
 			var report = routeSchemaManager.validateQuery(mockRequest);
 			assert(!report.valid, 'query obj should not be valid');
 			assert(report.errors, 'errors obj should be valid');
@@ -402,16 +402,16 @@ describe('RouteSchemaManager Unit Tests', function() {
 	});
 
 /*
-	                  888 d8b      888          888            8888888b.                   888                        888 
-	                  888 Y8P      888          888            888   Y88b                  888                        888 
-	                  888          888          888            888    888                  888                        888 
-	888  888  8888b.  888 888  .d88888  8888b.  888888 .d88b.  888   d88P 8888b.  888  888 888  .d88b.   8888b.   .d88888 
-	888  888     "88b 888 888 d88" 888     "88b 888   d8P  Y8b 8888888P"     "88b 888  888 888 d88""88b     "88b d88" 888 
-	Y88  88P .d888888 888 888 888  888 .d888888 888   88888888 888       .d888888 888  888 888 888  888 .d888888 888  888 
-	 Y8bd8P  888  888 888 888 Y88b 888 888  888 Y88b. Y8b.     888       888  888 Y88b 888 888 Y88..88P 888  888 Y88b 888 
-	  Y88P   "Y888888 888 888  "Y88888 "Y888888  "Y888 "Y8888  888       "Y888888  "Y88888 888  "Y88P"  "Y888888  "Y88888 
-	                                                                                   888                                
-	                                                                              Y8b d88P                                
+	                  888 d8b      888          888            8888888b.                   888                        888
+	                  888 Y8P      888          888            888   Y88b                  888                        888
+	                  888          888          888            888    888                  888                        888
+	888  888  8888b.  888 888  .d88888  8888b.  888888 .d88b.  888   d88P 8888b.  888  888 888  .d88b.   8888b.   .d88888
+	888  888     "88b 888 888 d88" 888     "88b 888   d8P  Y8b 8888888P"     "88b 888  888 888 d88""88b     "88b d88" 888
+	Y88  88P .d888888 888 888 888  888 .d888888 888   88888888 888       .d888888 888  888 888 888  888 .d888888 888  888
+	 Y8bd8P  888  888 888 888 Y88b 888 888  888 Y88b. Y8b.     888       888  888 Y88b 888 888 Y88..88P 888  888 Y88b 888
+	  Y88P   "Y888888 888 888  "Y88888 "Y888888  "Y888 "Y8888  888       "Y888888  "Y88888 888  "Y88P"  "Y888888  "Y88888
+	                                                                                   888
+	                                                                              Y8b d88P
 	                                                                               "Y88P"
 */
 	describe('validatePayload', function() {
@@ -419,7 +419,7 @@ describe('RouteSchemaManager Unit Tests', function() {
 
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				mockRequest = {
-					_route: mockRoute1,
+					route: mockRoute1,
 					payload: {
 						string: 'fnord'
 					},
@@ -431,7 +431,7 @@ describe('RouteSchemaManager Unit Tests', function() {
 						}
 					}
 				};
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, mockRoutes);
+			routeSchemaManager.initializeRoutes(mockRoutes);
 			var report = routeSchemaManager.validatePayload(mockRequest);
 			assert(report.valid, 'payload obj should be valid');
 		});
@@ -440,7 +440,7 @@ describe('RouteSchemaManager Unit Tests', function() {
 
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				mockRequest = {
-					_route: mockRoute1,
+					route: mockRoute1,
 					payload: {
 						string: 'fnord',
 						number: '1'
@@ -453,7 +453,7 @@ describe('RouteSchemaManager Unit Tests', function() {
 						}
 					}
 				};
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, mockRoutes);
+			routeSchemaManager.initializeRoutes(mockRoutes);
 			var report = routeSchemaManager.validatePayload(mockRequest);
 			assert(report.valid, 'payload obj should be valid');
 		});
@@ -463,7 +463,7 @@ describe('RouteSchemaManager Unit Tests', function() {
 			var data = fs.createReadStream('./test/jshint/config.json');
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				mockRequest = {
-					_route: mockRoute5,
+					route: mockRoute5,
 					payload: data,
 					raw: {
 						req: {
@@ -473,7 +473,7 @@ describe('RouteSchemaManager Unit Tests', function() {
 						}
 					}
 				};
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, [mockRoute5]);
+			routeSchemaManager.initializeRoutes([mockRoute5]);
 			var report = routeSchemaManager.validatePayload(mockRequest);
 			assert(report.valid, 'file payload should be valid');
 		});
@@ -483,7 +483,7 @@ describe('RouteSchemaManager Unit Tests', function() {
 			var data = fs.createReadStream('./test/jshint/config.json');
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				mockRequest = {
-					_route: mockRoute7,
+					route: mockRoute7,
 					payload: {
 						users: data,
 						numberArray: ['5', '6']
@@ -496,16 +496,16 @@ describe('RouteSchemaManager Unit Tests', function() {
 						}
 					}
 				};
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, [mockRoute7]);
+			routeSchemaManager.initializeRoutes([mockRoute7]);
 			var report = routeSchemaManager.validatePayload(mockRequest);
 			assert(report.valid, 'file payload with extra data should be valid');
 		});
-		
+
 		it('should validate payload for route with no payload schema successfully', function() {
 
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				mockRequest = {
-					_route: mockRoute2,
+					route: mockRoute2,
 					payload: {
 						string: 'fnord'
 					},
@@ -517,7 +517,7 @@ describe('RouteSchemaManager Unit Tests', function() {
 						}
 					}
 				};
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, mockRoutes);
+			routeSchemaManager.initializeRoutes(mockRoutes);
 			var report = routeSchemaManager.validatePayload(mockRequest);
 			assert(report.valid, 'payload obj should be valid');
 		});
@@ -526,7 +526,7 @@ describe('RouteSchemaManager Unit Tests', function() {
 
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				mockRequest = {
-					_route: mockRoute1,
+					route: mockRoute1,
 					payload: {
 						string: true
 					},
@@ -538,7 +538,7 @@ describe('RouteSchemaManager Unit Tests', function() {
 						}
 					}
 				};
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, mockRoutes);
+			routeSchemaManager.initializeRoutes(mockRoutes);
 			var report = routeSchemaManager.validatePayload(mockRequest);
 			assert(!report.valid, 'payload obj should not be valid');
 			assert(report.errors, 'errors obj should be valid');
@@ -548,7 +548,7 @@ describe('RouteSchemaManager Unit Tests', function() {
 
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				mockRequest = {
-					_route: mockRoute1,
+					route: mockRoute1,
 					payload: null,
 					raw: {
 						req: {
@@ -558,7 +558,7 @@ describe('RouteSchemaManager Unit Tests', function() {
 						}
 					}
 				};
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, mockRoutes);
+			routeSchemaManager.initializeRoutes(mockRoutes);
 			var report = routeSchemaManager.validatePayload(mockRequest);
 			assert(!report.valid, 'payload obj should not be valid');
 			assert(report.errors, 'errors obj should be valid');
@@ -568,7 +568,7 @@ describe('RouteSchemaManager Unit Tests', function() {
 
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				mockRequest = {
-					_route: mockRoute1,
+					route: mockRoute1,
 					payload: {
 						string: 'fnord'
 					},
@@ -578,7 +578,7 @@ describe('RouteSchemaManager Unit Tests', function() {
 						}
 					}
 				};
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, mockRoutes);
+			routeSchemaManager.initializeRoutes(mockRoutes);
 			var report = routeSchemaManager.validatePayload(mockRequest);
 			assert(!report.valid, 'payload obj should not be valid');
 			assert(report.errors, 'errors obj should be valid');
@@ -588,35 +588,35 @@ describe('RouteSchemaManager Unit Tests', function() {
 
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				mockRequest = {
-					_route: mockRoute6,
+					route: mockRoute6,
 					raw: {
 						req: {
 							headers: {}
 						}
 					}
 				};
-			routeSchemaManager.initializeRoutes(mockRoute6.server.info.uri, mockRoutes);
+			routeSchemaManager.initializeRoutes(mockRoutes);
 			var report = routeSchemaManager.validatePayload(mockRequest);
 			assert(report.valid, 'payload obj should be valid');
 		});
 	});
 
 /*
-	                  888 d8b      888          888            888    888                        888                           
-	                  888 Y8P      888          888            888    888                        888                           
-	                  888          888          888            888    888                        888                           
-	888  888  8888b.  888 888  .d88888  8888b.  888888 .d88b.  8888888888  .d88b.   8888b.   .d88888  .d88b.  888d888 .d8888b  
-	888  888     "88b 888 888 d88" 888     "88b 888   d8P  Y8b 888    888 d8P  Y8b     "88b d88" 888 d8P  Y8b 888P"   88K      
-	Y88  88P .d888888 888 888 888  888 .d888888 888   88888888 888    888 88888888 .d888888 888  888 88888888 888     "Y8888b. 
-	 Y8bd8P  888  888 888 888 Y88b 888 888  888 Y88b. Y8b.     888    888 Y8b.     888  888 Y88b 888 Y8b.     888          X88 
-	  Y88P   "Y888888 888 888  "Y88888 "Y888888  "Y888 "Y8888  888    888  "Y8888  "Y888888  "Y88888  "Y8888  888      88888P' 
+	                  888 d8b      888          888            888    888                        888
+	                  888 Y8P      888          888            888    888                        888
+	                  888          888          888            888    888                        888
+	888  888  8888b.  888 888  .d88888  8888b.  888888 .d88b.  8888888888  .d88b.   8888b.   .d88888  .d88b.  888d888 .d8888b
+	888  888     "88b 888 888 d88" 888     "88b 888   d8P  Y8b 888    888 d8P  Y8b     "88b d88" 888 d8P  Y8b 888P"   88K
+	Y88  88P .d888888 888 888 888  888 .d888888 888   88888888 888    888 88888888 .d888888 888  888 88888888 888     "Y8888b.
+	 Y8bd8P  888  888 888 888 Y88b 888 888  888 Y88b. Y8b.     888    888 Y8b.     888  888 Y88b 888 Y8b.     888          X88
+	  Y88P   "Y888888 888 888  "Y88888 "Y888888  "Y888 "Y8888  888    888  "Y8888  "Y888888  "Y88888  "Y8888  888      88888P'
 */
 	describe('validateHeaders', function() {
 		it('should validate header params for route successfully', function() {
 
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				mockRequest = {
-					_route: mockRoute1,
+					route: mockRoute1,
 					raw: {
 						req: {
 							headers: {
@@ -626,7 +626,7 @@ describe('RouteSchemaManager Unit Tests', function() {
 						}
 					}
 				};
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, mockRoutes);
+			routeSchemaManager.initializeRoutes(mockRoutes);
 			var report = routeSchemaManager.validateHeaders(mockRequest);
 			assert(report.valid, 'header obj should be valid');
 		});
@@ -635,7 +635,7 @@ describe('RouteSchemaManager Unit Tests', function() {
 
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				mockRequest = {
-					_route: mockRoute1,
+					route: mockRoute1,
 					raw: {
 						req: {
 							headers: {
@@ -645,7 +645,7 @@ describe('RouteSchemaManager Unit Tests', function() {
 						}
 					}
 				};
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, mockRoutes);
+			routeSchemaManager.initializeRoutes(mockRoutes);
 			var report = routeSchemaManager.validateHeaders(mockRequest);
 			assert(report.valid, 'header obj should be valid');
 		});
@@ -654,7 +654,7 @@ describe('RouteSchemaManager Unit Tests', function() {
 
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				mockRequest = {
-					_route: mockRoute2,
+					route: mockRoute2,
 					raw: {
 						req: {
 							headers: {
@@ -664,7 +664,7 @@ describe('RouteSchemaManager Unit Tests', function() {
 						}
 					}
 				};
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, mockRoutes);
+			routeSchemaManager.initializeRoutes(mockRoutes);
 			var report = routeSchemaManager.validateHeaders(mockRequest);
 			assert(report.valid, 'header obj should be valid');
 		});
@@ -673,7 +673,7 @@ describe('RouteSchemaManager Unit Tests', function() {
 
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				mockRequest = {
-					_route: mockRoute1,
+					route: mockRoute1,
 					raw: {
 						req: {
 							headers: {
@@ -682,7 +682,7 @@ describe('RouteSchemaManager Unit Tests', function() {
 						}
 					}
 				};
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, mockRoutes);
+			routeSchemaManager.initializeRoutes(mockRoutes);
 			var report = routeSchemaManager.validateHeaders(mockRequest);
 			assert(!report.valid, 'header obj should not be valid');
 			assert(report.errors, 'errors obj should be valid');
@@ -690,16 +690,16 @@ describe('RouteSchemaManager Unit Tests', function() {
 	});
 
 /*
-	                  888 d8b      888          888            8888888b.                                                                
-	                  888 Y8P      888          888            888   Y88b                                                               
-	                  888          888          888            888    888                                                               
-	888  888  8888b.  888 888  .d88888  8888b.  888888 .d88b.  888   d88P .d88b.  .d8888b  88888b.   .d88b.  88888b.  .d8888b   .d88b.  
-	888  888     "88b 888 888 d88" 888     "88b 888   d8P  Y8b 8888888P" d8P  Y8b 88K      888 "88b d88""88b 888 "88b 88K      d8P  Y8b 
-	Y88  88P .d888888 888 888 888  888 .d888888 888   88888888 888 T88b  88888888 "Y8888b. 888  888 888  888 888  888 "Y8888b. 88888888 
-	 Y8bd8P  888  888 888 888 Y88b 888 888  888 Y88b. Y8b.     888  T88b Y8b.          X88 888 d88P Y88..88P 888  888      X88 Y8b.     
-	  Y88P   "Y888888 888 888  "Y88888 "Y888888  "Y888 "Y8888  888   T88b "Y8888   88888P' 88888P"   "Y88P"  888  888  88888P'  "Y8888  
-	                                                                                       888                                          
-	                                                                                       888                                          
+	                  888 d8b      888          888            8888888b.
+	                  888 Y8P      888          888            888   Y88b
+	                  888          888          888            888    888
+	888  888  8888b.  888 888  .d88888  8888b.  888888 .d88b.  888   d88P .d88b.  .d8888b  88888b.   .d88b.  88888b.  .d8888b   .d88b.
+	888  888     "88b 888 888 d88" 888     "88b 888   d8P  Y8b 8888888P" d8P  Y8b 88K      888 "88b d88""88b 888 "88b 88K      d8P  Y8b
+	Y88  88P .d888888 888 888 888  888 .d888888 888   88888888 888 T88b  88888888 "Y8888b. 888  888 888  888 888  888 "Y8888b. 88888888
+	 Y8bd8P  888  888 888 888 Y88b 888 888  888 Y88b. Y8b.     888  T88b Y8b.          X88 888 d88P Y88..88P 888  888      X88 Y8b.
+	  Y88P   "Y888888 888 888  "Y88888 "Y888888  "Y888 "Y8888  888   T88b "Y8888   88888P' 88888P"   "Y88P"  888  888  88888P'  "Y8888
+	                                                                                       888
+	                                                                                       888
 	                                                                                       888
 */
 	describe('validateResponse', function() {
@@ -707,12 +707,12 @@ describe('RouteSchemaManager Unit Tests', function() {
 
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				mockRequest = {
-					_route: mockRoute1,
+					route: mockRoute1,
 					response: {
 						source: {string:'fnord'}
 					}
 				};
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, mockRoutes);
+			routeSchemaManager.initializeRoutes(mockRoutes);
 			var report = routeSchemaManager.validateResponse(mockRequest);
 			assert(report.valid, 'response obj should be valid');
 		});
@@ -721,12 +721,12 @@ describe('RouteSchemaManager Unit Tests', function() {
 
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				mockRequest = {
-					_route: mockRoute4,
+					route: mockRoute4,
 					response: {
 						source: 'fnord'
 					}
 				};
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, mockRoutes);
+			routeSchemaManager.initializeRoutes(mockRoutes);
 			var report = routeSchemaManager.validateResponse(mockRequest);
 			assert(report.valid, 'response string should be valid');
 		});
@@ -735,12 +735,12 @@ describe('RouteSchemaManager Unit Tests', function() {
 
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				mockRequest = {
-					_route: mockRoute2,
+					route: mockRoute2,
 					response: {
 						source: {string:'fnord'}
 					}
 				};
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, mockRoutes);
+			routeSchemaManager.initializeRoutes(mockRoutes);
 			var report = routeSchemaManager.validateResponse(mockRequest);
 			assert(report.valid, 'response obj should be valid');
 		});
@@ -749,12 +749,12 @@ describe('RouteSchemaManager Unit Tests', function() {
 
 			var routeSchemaManager = new RouteSchemaManager(rsmConfig),
 				mockRequest = {
-					_route: mockRoute1,
+					route: mockRoute1,
 					response: {
 						source: {string:true}
 					}
 				};
-			routeSchemaManager.initializeRoutes(mockRoute1.server.info.uri, mockRoutes);
+			routeSchemaManager.initializeRoutes(mockRoutes);
 			var report = routeSchemaManager.validateResponse(mockRequest);
 			assert(!report.valid, 'response obj should not be valid');
 			assert(report.errors, 'errors obj should be valid');

--- a/test/integration/ratify.tests.js
+++ b/test/integration/ratify.tests.js
@@ -2,34 +2,49 @@ var assert = require('assert'),
 	plugin = require('../../lib/ratify.js'),
 	Hapi = require('hapi');
 
-before(function(done) {
-	server = new Hapi.Server();
-	server.connection({ port: '8085', host: 'localhost', routes: { cors: true }});
-	server.register({
-		register: plugin,
-		options: { }
-	}, function (err) {
-		var get = function (request, reply) {
-			reply({ clientId: 'fnord', email: 'myemail@fake.com' });
-		};
+before(async function() {
+	server = new Hapi.Server({ port: '8085', host: 'localhost', routes: { cors: true }});
 
-		server.route({
-			method: 'GET',
-			path: '/clients/{clientId}',
-			handler: get,
-			config: {
-				plugins: {
-					ratify: {
-						headers: {
-							type: 'object',
-							properties: {
-								authorization: {
-									type: 'string',
-									description: 'A valid access token issued for a given client for accessing protected resources'
-								}
+	await server.register({
+		plugin,
+		options: { }
+	});
+	var get = function (request, h) {
+		return { clientId: 'fnord', email: 'myemail@fake.com' };
+	};
+
+	server.route({
+		method: 'GET',
+		path: '/clients/{clientId}',
+		handler: get,
+		config: {
+			plugins: {
+				ratify: {
+					headers: {
+						type: 'object',
+						properties: {
+							authorization: {
+								type: 'string',
+								description: 'A valid access token issued for a given client for accessing protected resources'
+							}
+						}
+					},
+					path: {
+						type: 'object',
+						properties: {
+							clientId: {
+								type: 'string',
+								minLength: 3,
+								pattern: '^[\\w_0-9-]+$',
+								description: 'A unique identifier for the client/user'
 							}
 						},
-						path: {
+						required: ['clientId']
+					},
+					response: {
+						sample: 100,
+						failAction: 'log',
+						schema: {
 							type: 'object',
 							properties: {
 								clientId: {
@@ -37,73 +52,50 @@ before(function(done) {
 									minLength: 3,
 									pattern: '^[\\w_0-9-]+$',
 									description: 'A unique identifier for the client/user'
+								},
+								email: {
+									type: 'string',
+									minLength: 3,
+									pattern: '^.+@.+$',
+									description: 'An email address associated to the client'
 								}
 							},
-							required: ['clientId']
-						},
-						response: {
-							sample: 100,
-							failAction: 'log',
-							schema: {
-								type: 'object',
-								properties: {
-									clientId: {
-										type: 'string',
-										minLength: 3,
-										pattern: '^[\\w_0-9-]+$',
-										description: 'A unique identifier for the client/user'
-									},
-									email: {
-										type: 'string',
-										minLength: 3,
-										pattern: '^.+@.+$',
-										description: 'An email address associated to the client'
-									}
-								},
-								required: ['clientId', 'email'],
-								additionalProperties: false
-							}
+							required: ['clientId', 'email'],
+							additionalProperties: false
 						}
 					}
 				}
 			}
-		});
-		server.route({ method: 'GET', path: '/test/{param}', handler: get });
-
-		done(err);
+		}
 	});
+	server.route({ method: 'GET', path: '/test/{param}', handler: get });
+
 });
 
 
 
 describe('ratify plugin tests', function() {
 
-	it('should provide a swagger docs end point', function(done) {
+	it('should provide a swagger docs end point', async function() {
 
-		server.inject('/api-docs', function (res) {
-			assert(res.statusCode === 200);
-			done();
-		});
+		const res = await server.inject('/api-docs');
+		assert(res.statusCode === 200);
 	});
 
-	it('should provide a swagger docs end point to a resource', function(done) {
+	it('should provide a swagger docs end point to a resource', async function() {
 
-		server.inject('/api-docs/clients', function (res) {
-			assert(res.statusCode === 200);
-			done();
-		});
+		const res = await server.inject('/api-docs/clients')
+		assert(res.statusCode === 200);
 	});
 
-	it('should validate path, headers, and response body against schema', function(done) {
+	it('should validate path, headers, and response body against schema', async function() {
 
-		server.inject({
+		const res = await server.inject({
 			url: '/clients/fnord',
 			headers: {
 				authorization: 'somekey'
 			}
-		}, function (res) {
-			assert(res.statusCode === 200);
-			done();
-		});
+		})
+		assert(res.statusCode === 200);
 	});
 });

--- a/test/jshint/config.json
+++ b/test/jshint/config.json
@@ -22,6 +22,7 @@
 	"maxdepth": 0,
 	"maxstatements": 0,
 	"maxcomplexity": 0,
+	"esversion": 6,
 
 	"asi": false,
 	"boss": true,


### PR DESCRIPTION
HAPI version 17 does not support the concept of connection https://github.com/hapijs/hapi/issues/3658 because of this what  `server.table()` returns changed
- V16 https://hapijs.com/api/16.6.2#servertablehost
- V17 https://hapijs.com/api/#-servertablehost

Because of this is the major change, and the flattening of `schemasByKey`, previous `schemasByServerUri`. Could ve possible replace this idea with `vhost` and use it to create the key.

Since the HAPI new API, introduces breaking changes this update does not escape that therefore, this is a mayor version update. 
 