### PR TITLE
Fix(swagger): Nested objects schema and default values should not be ignored

### DIFF
--- a/lib/SwaggerManager.js
+++ b/lib/SwaggerManager.js
@@ -277,6 +277,8 @@ var SwaggerManager = function(options) {
 					}
 
 					models[prefix + prop] = _.cloneDeep(model.properties[prop]);
+					// models[prefix + prop] may be a nested object, we should regenerate nested model:
+					generateNestedModels(models[prefix + prop], models, prefix, parent);
 					generateNestedModels(model.properties[prop], models, prefix, parent + prop + '.');
 					model.properties[prop] = { $ref: prefix + prop};
 				}

--- a/test/integration/ratify.tests.js
+++ b/test/integration/ratify.tests.js
@@ -58,6 +58,21 @@ before(function(done) {
 										minLength: 3,
 										pattern: '^.+@.+$',
 										description: 'An email address associated to the client'
+									},
+									nestedObject: {
+										type: 'object',
+										properties: {
+											nestedObject2: {
+												type: 'object',
+												properties: {
+													id: {
+														type: 'string',
+														description: 'sample id field',
+														defaultValue: '123'
+													}
+												}
+											},
+										}
 									}
 								},
 								required: ['clientId', 'email'],
@@ -90,6 +105,25 @@ describe('ratify plugin tests', function() {
 
 		server.inject('/api-docs/clients', function (res) {
 			assert(res.statusCode === 200);
+			done();
+		});
+	});
+
+	it('should generate correct models for deeply nested schema', function(done) {
+		server.inject('/api-docs/clients', function (res) {
+			assert(res.statusCode === 200);
+
+			var parsedPayload = JSON.parse(res.payload)
+
+			var nestedRef = parsedPayload.models.get_clients_by_clientId_response.properties.nestedObject.$ref;
+			assert(nestedRef === 'get_clients_by_clientId_response_nestedObject');
+			assert(parsedPayload.models[nestedRef].type === 'object');
+
+			var nestedRef2 = parsedPayload.models[nestedRef].properties.nestedObject2.$ref;
+			assert(nestedRef2 === 'get_clients_by_clientId_response_nestedObject2');
+			assert(parsedPayload.models[nestedRef2].properties.id.description === 'sample id field');
+			assert(parsedPayload.models[nestedRef2].properties.id.defaultValue === '123');
+
 			done();
 		});
 	});


### PR DESCRIPTION
### Description

- fixes a bug where nested object's schema and default values are ignored

| Before | After |
| - | - |
| <img width="500" alt="Screen Shot 2021-10-07 at 10 00 51 PM" src="https://user-images.githubusercontent.com/8777372/136487880-3115df8c-ad24-493a-b1fb-30e0f9aa61e9.png"> | <img width="400" alt="Screen Shot 2021-10-07 at 10 02 56 PM" src="https://user-images.githubusercontent.com/8777372/136487881-00250963-2e9f-40d4-ac19-40bd37a4c223.png"> <img width="243" alt="Screen Shot 2021-10-07 at 10 03 07 PM" src="https://user-images.githubusercontent.com/8777372/136487882-1da42404-841d-40af-8657-bde2d6110867.png"> |

### References

Bumped into this while working on https://auth0team.atlassian.net/browse/IAMRISK-1271

### Testing

- manually tested by linking it to local api2 and consuming generated schema in swagger management api explorer

### Checklist

- [x] This improves documentation at auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
